### PR TITLE
Improve Ordering of Search Results in Integrator Pages

### DIFF
--- a/website_oca_integrator/__manifest__.py
+++ b/website_oca_integrator/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Website OCA Integrator',
     'summary': 'Displays Integrators in website.',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Website',
     'license': 'AGPL-3',
     'website': 'https://github.com/OCA/oca-custom',

--- a/website_oca_integrator/controllers/main.py
+++ b/website_oca_integrator/controllers/main.py
@@ -81,7 +81,7 @@ class WebsiteIntegrator(http.Controller):
 
         # search integrators matching current search parameters
         integrator_ids = partner_obj.sudo().search(
-            base_integrator_domain, 
+            base_integrator_domain,
             order="grade_id ASC, implemented_count DESC,"
                   "contributor_count DESC, member_count DESC,"
                   "display_name ASC",

--- a/website_oca_integrator/controllers/main.py
+++ b/website_oca_integrator/controllers/main.py
@@ -81,7 +81,10 @@ class WebsiteIntegrator(http.Controller):
 
         # search integrators matching current search parameters
         integrator_ids = partner_obj.sudo().search(
-            base_integrator_domain, order="grade_id DESC, display_name ASC",
+            base_integrator_domain, 
+            order="grade_id ASC NULLS LAST, implemented_count DESC,"
+                  "contributor_count DESC, member_count DESC,"
+                  "display_name ASC",
             offset=pager['offset'], limit=self._references_per_page)
         integrators = integrator_ids.sudo()
 

--- a/website_oca_integrator/controllers/main.py
+++ b/website_oca_integrator/controllers/main.py
@@ -82,7 +82,7 @@ class WebsiteIntegrator(http.Controller):
         # search integrators matching current search parameters
         integrator_ids = partner_obj.sudo().search(
             base_integrator_domain, 
-            order="grade_id ASC NULLS LAST, implemented_count DESC,"
+            order="grade_id ASC, implemented_count DESC,"
                   "contributor_count DESC, member_count DESC,"
                   "display_name ASC",
             offset=pager['offset'], limit=self._references_per_page)


### PR DESCRIPTION
NOTE: Not actually tested, just edited in github after looking at Netherlands search results.

Platinum Sponsor was last, Gold sponsor next to last, no sponsors were first. Inverted grade_id ordering and put NULLS last, added implemented, contributor and member ordering to search as per this request

> Maxime has previously floated ordering by sponsorship level, then number of references, then # of contributors, then # of members 

\cc @OCA/board 

EDIT: Turns out ORM doesn't support NULLS in order by clauses, means it also doesn't support CASE statements which sucks. Anyway removed the NULLS last clause, its the default for ASC sorts anyway.