### PR TITLE
[ADD] missing modules

### DIFF
--- a/oca_all/__manifest__.py
+++ b/oca_all/__manifest__.py
@@ -135,6 +135,7 @@
         "document_page",
         "github_connector",
         "github_connector_odoo",
+        "github_connector_oca",
         "membership_delegated_partner_line",
         "membership_extension",
         "mis_builder",
@@ -158,6 +159,8 @@
         "web_refresher",
         "web_search_with_and",
         "web_widget_dropdown_dynamic",
+        "website_oca_integrator",
+        "website_sale_oca_apps",
     ],
     "installable": True,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,8 @@ odoo-addon-apps_product_creator = { git = "https://github.com/Therp/apps-store",
 
 # Unreleased addon sources (git), handled via uv.sources (NOT requirements/test-requirements)
 odoo-addon-membership_delegated_partner_line = { git = "https://github.com/gfcapalbo/vertical-association", branch = "18.0-MIG-membership_delegated_partner_line", subdirectory = "membership_delegated_partner_line" }
-
 odoo-addon-account_statement_import_online_wise = { git = "https://github.com/Therp/bank-statement-import", branch = "18.0-mig-account-statement-import-online-wise", subdirectory = "account_statement_import_online_wise" }
+odoo-addon-github_connector_oca = { git = "https://github.com/Therp/interface-github", branch = "18.0-mig-github_connector_oca", subdirectory = "github_connector_oca" }
 
 # Example to develop module from another repository in editable mode
 # odoo-addon-membership-delegated-partner-line = { path = "src/vertical-association/setup/membership_delegated_partner_line", editable = true }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,5 @@ pdfminer.six==20220319
 coverage[toml]
 odoo-addon-membership-delegated-partner-line @ git+https://github.com/gfcapalbo/vertical-association.git@18.0-MIG-membership_delegated_partner_line#subdirectory=membership_delegated_partner_line
 odoo-addon-account_statement_import_online_wise @ git+https://github.com/Therp/bank-statement-import@18.0-mig-account-statement-import-online-wise#subdirectory=account_statement_import_online_wise
+odoo-addon-github_connector_oca @ git+https://github.com/Therp/interface-github.git@18.0-mig-github_connector_oca#subdirectory=github_connector_oca
 odoo-addon-apps_product_creator @ git+https://github.com/Therp/apps-store.git@18.0-mig-apps_product_creator#subdirectory=apps_product_creator

--- a/uv.lock
+++ b/uv.lock
@@ -642,6 +642,7 @@ dependencies = [
     { name = "odoo-addon-account-statement-import-online-wise" },
     { name = "odoo-addon-account-tax-unece" },
     { name = "odoo-addon-account-usability" },
+    { name = "odoo-addon-apps-product-creator" },
     { name = "odoo-addon-base-technical-features" },
     { name = "odoo-addon-base-ubl" },
     { name = "odoo-addon-base-unece" },
@@ -652,6 +653,7 @@ dependencies = [
     { name = "odoo-addon-document-knowledge" },
     { name = "odoo-addon-document-page" },
     { name = "odoo-addon-github-connector" },
+    { name = "odoo-addon-github-connector-oca" },
     { name = "odoo-addon-github-connector-odoo" },
     { name = "odoo-addon-membership-delegated-partner-line" },
     { name = "odoo-addon-membership-extension" },
@@ -696,6 +698,7 @@ dependencies = [
     { name = "qrcode" },
     { name = "reportlab" },
     { name = "requests" },
+    { name = "responses" },
     { name = "rjsmin" },
     { name = "urllib3" },
     { name = "vobject" },
@@ -759,6 +762,7 @@ requires-dist = [
     { name = "odoo-addon-account-statement-import-online-wise", git = "https://github.com/Therp/bank-statement-import?subdirectory=account_statement_import_online_wise&branch=18.0-mig-account-statement-import-online-wise" },
     { name = "odoo-addon-account-tax-unece", specifier = "==18.0.*" },
     { name = "odoo-addon-account-usability", specifier = "==18.0.*" },
+    { name = "odoo-addon-apps-product-creator", git = "https://github.com/Therp/apps-store?subdirectory=apps_product_creator&branch=18.0-mig-apps_product_creator" },
     { name = "odoo-addon-base-technical-features", specifier = "==18.0.*" },
     { name = "odoo-addon-base-ubl", specifier = "==18.0.*" },
     { name = "odoo-addon-base-unece", specifier = "==18.0.*" },
@@ -769,6 +773,7 @@ requires-dist = [
     { name = "odoo-addon-document-knowledge", specifier = "==18.0.*" },
     { name = "odoo-addon-document-page", specifier = "==18.0.*" },
     { name = "odoo-addon-github-connector", specifier = "==18.0.*" },
+    { name = "odoo-addon-github-connector-oca", git = "https://github.com/Therp/interface-github?subdirectory=github_connector_oca&branch=18.0-mig-github_connector_oca" },
     { name = "odoo-addon-github-connector-odoo", specifier = "==18.0.*" },
     { name = "odoo-addon-membership-delegated-partner-line", git = "https://github.com/gfcapalbo/vertical-association?subdirectory=membership_delegated_partner_line&branch=18.0-MIG-membership_delegated_partner_line" },
     { name = "odoo-addon-membership-extension", specifier = "==18.0.*" },
@@ -813,6 +818,7 @@ requires-dist = [
     { name = "qrcode", specifier = "==7.4.2" },
     { name = "reportlab", specifier = "==4.1.0" },
     { name = "requests", specifier = "==2.31.0" },
+    { name = "responses" },
     { name = "rjsmin", specifier = "==1.2.0" },
     { name = "urllib3", specifier = "==2.0.7" },
     { name = "vobject", specifier = "==0.9.6.1" },
@@ -1144,6 +1150,16 @@ wheels = [
 ]
 
 [[package]]
+name = "odoo-addon-apps-product-creator"
+version = "18.0.1.0.0"
+source = { git = "https://github.com/Therp/apps-store?subdirectory=apps_product_creator&branch=18.0-mig-apps_product_creator#4fc0f060dcb0e68e69e0659929ab62d224e5e8fd" }
+dependencies = [
+    { name = "odoo" },
+    { name = "odoo-addon-github-connector-oca" },
+    { name = "odoo-addon-github-connector-odoo" },
+]
+
+[[package]]
 name = "odoo-addon-base-technical-features"
 version = "18.0.1.0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1256,6 +1272,15 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/15/f3bbdd74884e80a828c185060226f3a0681c275aa8a782b1fabbdea33501/odoo_addon_github_connector-18.0.1.0.0.2-py3-none-any.whl", hash = "sha256:a49d9a18f63bd69933f6d5759ea2529b67f04f9ab19a22839cdafb2aafebadc8", size = 583615, upload-time = "2025-05-21T11:47:23.966Z" },
+]
+
+[[package]]
+name = "odoo-addon-github-connector-oca"
+version = "18.0.1.0.0"
+source = { git = "https://github.com/Therp/interface-github?subdirectory=github_connector_oca&branch=18.0-mig-github_connector_oca#bc3f6da8e1f5ef81b3c0b8a0a0f524dfae32d4e9" }
+dependencies = [
+    { name = "odoo" },
+    { name = "odoo-addon-github-connector-odoo" },
 ]
 
 [[package]]
@@ -1920,6 +1945,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
 name = "qrcode"
 version = "7.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1983,6 +2026,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Because there is currently a dependency of `website_oca_integrator` on `apps_product_creator` and therefore on `github_connector_oca`, all these modules need to be added to the build.

Later on we will remove the dependency of `website_oca_integrator` on these modules and remove them, and also deinstall the whole `github_connector`.