### PR TITLE
[18.0] Mark unreleased dependency job as non-blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,14 @@ jobs:
                   grep "^[^#].*/" ${reqfile} || result=$?
                   if [ $result -eq 0 ] ; then
                   echo "::warning:: Unreleased dependencies found in ${reqfile}."
-                      exit 0
+                      exit 1
                   fi
               fi
           done
+    env:
+      GITHUB_STATUS_IGNORED: "0"
+      GITHUB_CHECK_SUITES_IGNORED: "unreleased-deps, "
+      
   test:
     runs-on: ubuntu-22.04
     container: ${{ matrix.container }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
   unreleased-deps:
     runs-on: ubuntu-latest
     name: Detect unreleased dependencies
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -22,8 +23,8 @@ jobs:
                   # reject non-comment lines that contain a / (i.e. URLs, relative paths)
                   grep "^[^#].*/" ${reqfile} || result=$?
                   if [ $result -eq 0 ] ; then
-                      echo "Unreleased dependencies found in ${reqfile}."
-                      exit 1
+                  echo "::warning:: Unreleased dependencies found in ${reqfile}."
+                      exit 0
                   fi
               fi
           done


### PR DESCRIPTION
WIP/ added a ci modification to allow return 0 check on dependency failure.
dependency should be advisory, not return 1 in workflow.

this MR  was inspired by   #105 ,  where the dependency check job is red 

With our ci changes the result is

<img width="1730" height="757" alt="image" src="https://github.com/user-attachments/assets/aab8a0c1-ae83-4298-aa5f-99290383a1d9" />
