### PR TITLE
[18.0][FIX] _get_optional_fields

### DIFF
--- a/website_oca_integrator/controllers/portal.py
+++ b/website_oca_integrator/controllers/portal.py
@@ -8,6 +8,18 @@ from odoo.addons.portal.controllers.portal import CustomerPortal
 
 
 class IntegratorPortal(CustomerPortal):
+    def _get_optional_fields(self):
+        fields = list(super()._get_optional_fields())
+        for f in [
+            "website_short_description",
+            "website_description",
+            "favourite_module_ids",
+            "github_organization",
+        ]:
+            if f not in fields:
+                fields.append(f)
+        return fields
+
     @route()
     def account(self, redirect=None, **post):
         if post:


### PR DESCRIPTION
Fixes:

- As a portal user, try to edit the profile (eg the address)


error:

Some required fields are empty.
Unknown field 'website_short_description,website_description,favourite_module_ids'