### PR TITLE
[FIX] Standard neutralization script

### DIFF
--- a/entrypoints/000_08_standard-neutralize
+++ b/entrypoints/000_08_standard-neutralize
@@ -31,11 +31,11 @@ def main(env):
             "RUNNING_ENV is not defined, please set a RUNNING_ENV and try again"
         )
         sys.exit(1)
-    if running_env == "prod":
+    if running_env == "prod" or "prod" in env.registry.db_name:
         _logger.info("%s database, no need to neutralize...", running_env)
         sys.exit(0)
-    _logger.info("Neutralization would run")
-    # neutralize_db(env)
+
+    neutralize_db(env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Calling Odoo neutralization had been disabled because of a suspected fluke in how it was set up, leading to a neutralized production database. With this attempt, we switch it back on, so that neutralization can be set up via the standard `neutralize.sql` scripts, and for modules like for example the Wise and Stripe integration, we get neutralization out of the box instead of having to add manual SQL entries to our entrypoints.