### PR TITLE
[ADD] group_messages_robots template

### DIFF
--- a/oca_membership_groups/__manifest__.py
+++ b/oca_membership_groups/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     "data": [
         "data/ir_cron_data.xml",
+        "templates/mail_group.xml",
         "views/mail_group.xml",
         "views/mail_group_member.xml",
         "views/membership_category.xml",

--- a/oca_membership_groups/templates/mail_group.xml
+++ b/oca_membership_groups/templates/mail_group.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="group_messages_robots" inherit_id="mail_group.group_messages" name="Mail Groups - Robots noindex">
+        <xpath expr="//t[@t-call='portal.portal_layout']" position="before">
+	    <t t-set="website_indexed" t-value="False"/>
+	</xpath>
+    </template>  
+</odoo>


### PR DESCRIPTION
Inherit mail_group.group_messages qweb view in order to add a <meta name="robots" content="noindex"> tag on all pages off the following /groups directory