### PR TITLE
[IMP] oca_sponsor: order by name

### DIFF
--- a/oca_sponsor/models/res_partner.py
+++ b/oca_sponsor/models/res_partner.py
@@ -204,7 +204,7 @@ class ResPartner(models.Model):
         with the ones to review at first"""
         if self._context.get("membership_sponsor"):
             delimiter = "" if not order else ", "
-            order = "sponsor_to_review DESC" + delimiter + (order or "")
+            order = "sponsor_to_review DESC, name ASC" + delimiter + (order or "")
         return super().search_fetch(domain, field_names, offset, limit, order)
 
     # ===== Actions & buttons =====#


### PR DESCRIPTION
In menu "Members / Sponsor", continue ordering the Kanban view with sponsor to validate at first, but order the other ones by their names