### PR TITLE
[18.0] oca_membership_*: small fixes

### DIFF
--- a/oca_membership/models/res_partner.py
+++ b/oca_membership/models/res_partner.py
@@ -43,12 +43,6 @@ class ResPartner(models.Model):
         compute="_compute_membership_state",
         help="Categories of active membership lines plus Current Category.",
     )
-    # Mail Groups: needed for for `oca_search_engine`,
-    # rest is in `oca_membership_groups`
-    mail_group_member_ids = fields.One2many(
-        comodel_name="mail.group.member",
-        inverse_name="partner_id",
-    )
     # website privacy
     is_published = fields.Boolean(
         tracking=True,

--- a/oca_search_engine/models/__init__.py
+++ b/oca_search_engine/models/__init__.py
@@ -1,4 +1,6 @@
 from . import blog_post
+from . import mail_group
+from . import mail_group_member
 from . import res_partner
 from . import se_index
 from . import vcp_odoo_module_version

--- a/oca_search_engine/models/mail_group.py
+++ b/oca_search_engine/models/mail_group.py
@@ -1,0 +1,17 @@
+# Copyright 2026 AKRETION
+# @author Arnaud LAYEC <arnaud.layec@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailGroup(models.Model):
+    _inherit = "mail.group"
+
+    def write(self, vals):
+        """Refresh partners data on the Search Engine
+        when a Mail Group is promoted/destituted a Working Group"""
+        res = super().write(vals)
+        if "is_working_group" in vals:
+            self.sudo().member_ids.partner_id._se_mark_to_update()
+        return res

--- a/oca_search_engine/models/mail_group_member.py
+++ b/oca_search_engine/models/mail_group_member.py
@@ -1,0 +1,33 @@
+# Copyright 2026 AKRETION
+# @author Arnaud LAYEC <arnaud.layec@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class MailGroupMember(models.Model):
+    """Refresh partners data on the Search Engine
+    when added/removed to a Working Group"""
+
+    _inherit = "mail.group.member"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._se_update_partners()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._se_update_partners()
+        return res
+
+    def unlink(self):
+        partner = self.partner_id
+        res = super().unlink()
+        partner.sudo()._se_mark_to_update()
+        return res
+
+    def _se_update_partners(self):
+        wg_members = self.filtered(lambda x: x.mail_group_id.is_working_group)
+        wg_members.sudo().partner_id._se_mark_to_update()

--- a/oca_sponsor/models/res_partner.py
+++ b/oca_sponsor/models/res_partner.py
@@ -204,7 +204,7 @@ class ResPartner(models.Model):
         with the ones to review at first"""
         if self._context.get("membership_sponsor"):
             delimiter = "" if not order else ", "
-            order = "sponsor_to_review DESC" + delimiter + (order or "")
+            order = "sponsor_to_review DESC, name ASC" + delimiter + (order or "")
         return super().search_fetch(domain, field_names, offset, limit, order)
 
     # ===== Actions & buttons =====#


### PR DESCRIPTION
- Also order sponsor by name in the Kanban view "Members / Sponsor"
- Trigger Search Engine data synchro when updating member's Working Group data

