### PR TITLE
[FIX] oca_sponsor: Prevent 'not a member of the team' issue when a sp…

### DIFF
--- a/oca_sponsor/models/res_partner.py
+++ b/oca_sponsor/models/res_partner.py
@@ -239,7 +239,9 @@ class ResPartner(models.Model):
         else:
             self.activity_schedule(
                 team_id=reviewer_team.id,
-                team_user_id=reviewer_team.user_id.id,
+                # 'user_id' is needed else it defaults to self.env.uid (the sponsor)
+                # and throws an error like "not a member of the team"
+                user_id=reviewer_team.user_id.id,
                 note=_(
                     "The sponsor changed its information from its profile. "
                     "Please review those changes to publish them on the website."


### PR DESCRIPTION
…onsor modifies its data in self-service

@sebastienbeau @bguillot : could you please review & push to prod ?
This is a fix currently blocking the sponsors to modify their data on the website

@TumbaoJu FYI