### PR TITLE
[FIX] oca_search_engine: stop synching archived partners

### DIFF
--- a/oca_membership/views/portal_templates.xml
+++ b/oca_membership/views/portal_templates.xml
@@ -148,7 +148,7 @@
                         t-att-checked="partner.is_published_address"
                     />
                     <label for="is_published_address">
-                        Publish location the website (address &amp; city)
+                        Publish location on the website (address &amp; city)
                     </label>
                 </div>
 

--- a/oca_search_engine/models/res_partner.py
+++ b/oca_search_engine/models/res_partner.py
@@ -45,7 +45,12 @@ class ResPartner(models.Model):
         index_companies = self.env.ref(INDEX_COMPANIES)
         index_persons = self.env.ref(INDEX_PERSONS)
 
-        if vals and "is_published" in vals and not vals["is_published"]:
+        if vals and (
+            "is_published" in vals
+            and not vals["is_published"]
+            or "active" in vals
+            and not vals["active"]
+        ):
             self._remove_from_index(index_companies | index_persons)
         else:
             self._autopublish_companies(vals)


### PR DESCRIPTION
# oca_search_engine
- Remove from the website the archived partner in Odoo

# oca_membership
- Fix a typo in the public website, "/my/account" page